### PR TITLE
replace deprecated dash app.run_server with app.run

### DIFF
--- a/jaal/jaal.py
+++ b/jaal/jaal.py
@@ -339,4 +339,4 @@ class Jaal:
         # call the create_graph function
         app = self.create(directed=directed, vis_opts=vis_opts)
         # run the server
-        app.run_server(debug=debug, host=host, port=port)
+        app.run(debug=debug, host=host, port=port)


### PR DESCRIPTION
app.run_server is deprecated and fails to execute with recent dash v3.0.2:

"dash.exceptions.ObsoleteAttributeException: app.run_server has been replaced by app.run"

See for dash API reference:
https://dash.plotly.com/reference