### PR TITLE
Differentiate tool-tip title from node label

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ By default, `Jaal` plot undirected edges. This setting can be changed by,
 Jaal(edge_df, node_df).plot(directed=True)
 ```
 
-### Showing Custom Title
+### Showing Custom Label
 
-By default, `id` is shown as title. To overwrite this, include a `title` column with the respective data.
+By default, `id` is shown as label. To overwrite this, include a `label` column with the respective data.
 
 ### Showing Tooltip
 
-By default, `nodeid` is shown as tooltip. To overwrite this, include a `title` column with the respective data.
+By default, `id` is shown as tooltip. To overwrite this, include a `title` column with the respective data.
 
 ### Using vis.js settings
 

--- a/jaal/datasets/parse_dataframe.py
+++ b/jaal/datasets/parse_dataframe.py
@@ -57,7 +57,10 @@ def parse_dataframe(edge_df, node_df=None):
         node_df = node_df.astype({'id': str})
         # remove blanks cols
         node_df = node_df.dropna(axis=1)
-        # if title is not present, make it same as label
+        # if label is not present, make it same as id
+        if 'label' not in node_df.columns:
+            node_df['label'] = node_df['id']
+        # if title is not present, make it same as id
         if 'title' not in node_df.columns:
             node_df['title'] = node_df['id']
         # see if node imge url is present or not
@@ -65,9 +68,9 @@ def parse_dataframe(edge_df, node_df=None):
         # create the node data
         for node in node_df.to_dict(orient='records'):
             if not node_image_url_flag:
-                nodes.append({**node, **{'label': node['title'], 'shape': 'dot', 'size': 7}})
+                nodes.append({**node, **{'shape': 'dot', 'size': 7}})
             else:
-                nodes.append({**node, **{'label': node['title'], 'shape': 'circularImage',
+                nodes.append({**node, **{'shape': 'circularImage',
                                 'image': node['node_image_url'], 
                                 'size': 20}})
 


### PR DESCRIPTION
Allow to define custom 'label' and custom 'title' in the same time. This fixes an issue of overwriting 'label' with 'title'